### PR TITLE
docs: 単層スタックのマージ手順を追加 #12

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,7 @@
       "Bash(gh pr view*)",
       "Bash(gh pr list*)",
       "Bash(gh pr diff*)",
+      "Bash(gh pr merge*)",
       "Bash(gh stack view*)",
       "Bash(gh stack up*)",
       "Bash(gh stack down*)",

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -120,5 +120,6 @@ terraform test
 5. `main` が進んだら `gh stack sync` でスタック全体を追従させます。
 6. `gh stack merge` でスタックをまとめてマージし、`gh stack sync --prune` で後片付けします。
 
-GitHub の Merge ボタンや `gh pr merge` による個別マージはスタックの整合性が崩れるため使いません。
+2 層以上のスタックでは、GitHub の Merge ボタンや `gh pr merge` による個別マージはスタックの整合性が崩れるため使いません。
+1 層だけのスタックは `gh stack merge` が使えないため、`gh pr merge <番号> --rebase --delete-branch` でマージします。
 分割の粒度やコンフリクト時の対処など、詳しい手順は [Stacked PRs 運用ガイド](./STACKED_PRS.md) を参照してください。

--- a/.github/STACKED_PRS.md
+++ b/.github/STACKED_PRS.md
@@ -30,7 +30,7 @@ PR 画面にスタック全体が表示され、レビュアーは階層を行�
 ### 制約
 
 - **スタックは直線のみ**。1 つの親に複数の子をぶら下げる分岐構造は作れません（分けたいときは別スタックにします）
-- **`gh pr merge` は使えません**。スタックのマージは `gh stack merge` を使います
+- **2 層以上のスタックで `gh pr merge` は使えません**。まとめて `gh stack merge` でマージします（1 層だけのスタックは GitHub 上に stack が作られないため `gh pr merge` を使います）
 - スタックのメタデータは `.git/gh-stack`（JSON）に保存されます。リポジトリにはコミットされないローカル情報です
 
 ## セットアップ
@@ -186,8 +186,16 @@ gh stack merge 42              # PR #42 までをマージ
 gh stack merge --yes --squash  # 確認なしで全部を squash マージ
 ```
 
-> `gh pr merge` や GitHub 画面の Merge ボタンによる個別マージは、スタックの整合性が崩れるため使わないでください。
+> 2 層以上のスタックでは、`gh pr merge` や GitHub 画面の Merge ボタンによる個別マージを使わないでください。スタックの整合性が崩れます。
 
+1 層だけのスタックは GitHub 上に stack が作られず、`gh stack merge` が `this stack has not been submitted to GitHub yet` で失敗します。この場合は `gh pr merge` を使います。
+
+```bash
+gh pr merge <PR番号> --rebase --delete-branch   # 単層のときのみ
+git remote prune origin
+```
+
+履歴を直線に保つため、マージ方式は `--rebase` に揃えます。
 マージ後は `gh stack sync --prune` でローカルを掃除します。
 
 ## コマンド早見表
@@ -203,7 +211,8 @@ gh stack merge --yes --squash  # 確認なしで全部を squash マージ
 | `gh stack submit` | push + PR 作成 + GitHub 上で Stack 化 |
 | `gh stack sync` | fetch → rebase → push → PR 同期（`--prune` で掃除） |
 | `gh stack rebase` | 明示的な rebase（`--upstack` / `--downstack` / `--continue` / `--abort`） |
-| `gh stack merge` | スタックをまとめてマージ |
+| `gh stack merge` | スタックをまとめてマージ（2 層以上） |
+| `gh pr merge <番号> --rebase --delete-branch` | 1 層だけのスタックのマージ |
 | `gh stack checkout <番号\|ブランチ>` | スタック番号・PR 番号・ブランチ名で切り替え |
 | `gh stack modify` | 対話的にスタックを再構成 |
 | `gh stack unstack` | Stack の紐付けを解除（PR やブランチは消えない） |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,11 +164,22 @@ gh stack init feat/1-memo-usecase       # 1 層目を main から作成
 
 ### マージ
 
+**2 層以上**のスタックは `gh stack merge` でまとめてマージします。
+
 ```bash
 gh stack merge          # 下から順に all-or-nothing でマージ
 gh stack sync --prune   # マージ後の後片付け
 ```
 
+**1 層だけ**のスタックは GitHub 上に stack が作られず `gh stack merge` が使えないため、`gh pr merge` を使います。
+
+```bash
+gh pr merge <PR番号> --rebase --delete-branch
+git remote prune origin
+```
+
+- 履歴を直線に保つため、マージ方式は `--rebase` に揃える。
+- 2 層以上のスタックで `gh pr merge` や GitHub の Merge ボタンを使わない。整合性が崩れる。
 - マージ後は対応する Issue の DoD を確認し、**「まとめ」を記入してから** `Status` を `Done` にする。実施期間が予定とずれていたら実績に合わせて直す。
 
 ## コーディング規約


### PR DESCRIPTION
## 概要

1 層だけのスタックは GitHub 上に stack が作られず `gh stack merge` が使えないため、単層時は `gh pr merge` を使うことをドキュメントに明記する。

## 変更内容

- `AGENTS.md`: 2 層以上は `gh stack merge`、1 層のみは `gh pr merge <番号> --rebase --delete-branch` を使うことを記載
- `.github/STACKED_PRS.md`: 「制約」と「マージする」から `gh pr merge` の全面禁止を外し、単層時の例外とコマンドを追記。早見表にも追加
- `.github/CONTRIBUTING.md`: 個別マージの禁止を「2 層以上」に限定
- 履歴を直線に保つため、マージ方式は `--rebase` に揃えることを明記
- `.claude/settings.json`: `Bash(gh pr merge*)` を allow に追加

## 確認方法

- `AGENTS.md`「マージ」と `.github/STACKED_PRS.md`「8. マージする」の記述確認

## チェックリスト

- [ ] `mise run lint` / `mise run format` が通る（`@memo-app/api` の既存エラーで失敗。本 PR は `apps/api` を変更していない）
- [ ] `mise run test` が通る（未実行）
- [x] スタックの一部の場合、この層に属する変更だけが入っている

## 関連

Closes #12
