### PR TITLE
docs: マージ方式をマージコミットに統一 #33

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -69,7 +69,7 @@ make dev
 | `gh stack view`       | スタックの状態を表示                        |
 | `gh stack submit`     | push + PR 作成 + GitHub 上で Stack 化       |
 | `gh stack sync`       | `main` の変更を取り込みスタック全体を同期   |
-| `gh stack merge`      | スタックをまとめてマージ                    |
+| `gh stack merge --merge` | スタックをまとめてマージ                 |
 
 詳細は [Stacked PRs 運用ガイド](./guides/STACKED_PRS.md) を参照してください。
 
@@ -135,10 +135,12 @@ terraform test
 3. `gh stack view` でスタック構造を確認します。
 4. `gh stack submit` で全 PR をまとめて作成し、GitHub 上で Stack として紐付けます。
 5. `main` が進んだら `gh stack sync` でスタック全体を追従させます。
-6. `gh stack merge` でスタックをまとめてマージし、`gh stack sync --prune` で後片付けします。
+6. `gh stack merge --merge` でスタックをまとめてマージし、`gh stack sync --prune` で後片付けします。
+
+マージ方式は `--merge`（マージコミット）に統一します。理由は [Discussion #32](https://github.com/Hitamuki/study-web-modern-stack/discussions/32) を参照してください。
 
 2 層以上のスタックでは、GitHub の Merge ボタンや `gh pr merge` による個別マージはスタックの整合性が崩れるため使いません。
-1 層だけのスタックは `gh stack merge` が使えないため、`gh pr merge <番号> --rebase --delete-branch` でマージします。
+1 層だけのスタックは `gh stack merge` が使えないため、`gh pr merge <番号> --merge` でマージします。
 分割の粒度やコンフリクト時の対処など、詳しい手順は [Stacked PRs 運用ガイド](./guides/STACKED_PRS.md) を参照してください。
 
 ## コードレビュー

--- a/.github/guides/STACKED_PRS.md
+++ b/.github/guides/STACKED_PRS.md
@@ -181,9 +181,9 @@ gh stack rebase --abort
 スタックは下から順に、**all-or-nothing** でまとめてマージされます（1 つでも失敗すれば全部マージされません）。
 
 ```bash
-gh stack merge                 # 対話ウィザードでマージ範囲と方式を選ぶ
-gh stack merge 42              # PR #42 までをマージ
-gh stack merge --yes --squash  # 確認なしで全部を squash マージ
+gh stack merge --merge         # 対話ウィザードでマージ範囲を選ぶ（方式は --merge で固定）
+gh stack merge 42 --merge      # PR #42 までをマージ
+gh stack merge --yes --merge   # 確認なしで全部をマージコミットでマージ
 ```
 
 > 2 層以上のスタックでは、`gh pr merge` や GitHub 画面の Merge ボタンによる個別マージを使わないでください。スタックの整合性が崩れます。
@@ -191,11 +191,18 @@ gh stack merge --yes --squash  # 確認なしで全部を squash マージ
 1 層だけのスタックは GitHub 上に stack が作られず、`gh stack merge` が `this stack has not been submitted to GitHub yet` で失敗します。この場合は `gh pr merge` を使います。
 
 ```bash
-gh pr merge <PR番号> --rebase --delete-branch   # 単層のときのみ
+gh pr merge <PR番号> --merge   # 単層のときのみ
 git remote prune origin
 ```
 
-履歴を直線に保つため、マージ方式は `--rebase` に揃えます。
+マージ方式は **`--merge`（マージコミット）に統一**します。`--squash` / `--rebase` は使わず、PR のサイズで方式を変えません。
+承認の単位を履歴に残すためで、理由は [Discussion #32](https://github.com/Hitamuki/study-web-modern-stack/discussions/32) にあります。
+
+- PR 単位で履歴を読む: `git log --first-parent --oneline`
+- コミット単位で読む: `git log --oneline`
+- PR 単位で巻き戻す: `git revert -m 1 <マージコミット>`
+
+リモートブランチはリポジトリ設定（`deleteBranchOnMerge`）でマージ時に自動削除されるため、`--delete-branch` は不要です。
 マージ後は `gh stack sync --prune` でローカルを掃除します。
 
 ## コマンド早見表
@@ -211,8 +218,8 @@ git remote prune origin
 | `gh stack submit` | push + PR 作成 + GitHub 上で Stack 化 |
 | `gh stack sync` | fetch → rebase → push → PR 同期（`--prune` で掃除） |
 | `gh stack rebase` | 明示的な rebase（`--upstack` / `--downstack` / `--continue` / `--abort`） |
-| `gh stack merge` | スタックをまとめてマージ（2 層以上） |
-| `gh pr merge <番号> --rebase --delete-branch` | 1 層だけのスタックのマージ |
+| `gh stack merge --merge` | スタックをまとめてマージ（2 層以上） |
+| `gh pr merge <番号> --merge` | 1 層だけのスタックのマージ |
 | `gh stack checkout <番号\|ブランチ>` | スタック番号・PR 番号・ブランチ名で切り替え |
 | `gh stack modify` | 対話的にスタックを再構成 |
 | `gh stack unstack` | Stack の紐付けを解除（PR やブランチは消えない） |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,21 +276,26 @@ gh stack init feat/1-memo-usecase       # 1 層目を main から作成
 
 ### マージ
 
+マージ方式は **`--merge`（マージコミット）に統一**します。`main` のコミット列は「AI の出力を人間が承認した記録」であり、
+承認の単位（＝どこまでが一度に承認された塊か）を履歴に残すためです（[Discussion #32](https://github.com/Hitamuki/study-web-modern-stack/discussions/32)）。
+
 **2 層以上**のスタックは `gh stack merge` でまとめてマージします。
 
 ```bash
-gh stack merge          # 下から順に all-or-nothing でマージ
-gh stack sync --prune   # マージ後の後片付け
+gh stack merge --merge   # 下から順に all-or-nothing でマージ
+gh stack sync --prune    # マージ後の後片付け
 ```
 
 **1 層だけ**のスタックは GitHub 上に stack が作られず `gh stack merge` が使えないため、`gh pr merge` を使います。
 
 ```bash
-gh pr merge <PR番号> --rebase --delete-branch
+gh pr merge <PR番号> --merge
 git remote prune origin
 ```
 
-- 履歴を直線に保つため、マージ方式は `--rebase` に揃える。
+- マージ方式は `--merge` に揃える。`--squash` / `--rebase` は使わない。PR のサイズで方式を変えない。
+- 履歴は PR 単位なら `git log --first-parent`、コミット単位なら素の `git log` で読む。
+- PR 単位で巻き戻すときは `git revert -m 1 <マージコミット>` を使う。
 - 2 層以上のスタックで `gh pr merge` や GitHub の Merge ボタンを使わない。整合性が崩れる。
 - マージ後は対応する Issue の **AC / DoD をチェックし、「まとめ」を記入してから** `Status` を `Done` にする（「完了時の手順」を参照）。実施期間が予定とずれていたら実績に合わせて直す。
 


### PR DESCRIPTION
## 概要

Discussion #32 の決着（`main` へのマージ方式を `--merge`（マージコミット）に統一する）をドキュメントに反映します。
Discussion #18 で `--rebase` に決めていましたが、7 つの規範のうちこの項目だけが軸からも反証条件からも導かれておらず、
根拠が「実績（マージコミット 0 件）」の 1 行で循環していたため、本質から導出しなおしました。

## 変更内容

- `AGENTS.md`「マージ」節を `--merge` 前提に変更。冒頭に方式と理由（Discussion #32 へのリンク）を追加
- **「履歴を直線に保つため」を規範から取り下げ**、`git log --first-parent` / `git log` の 2 粒度での読み方と `git revert -m 1` に差し替え
- `.github/guides/STACKED_PRS.md` のマージ手順・コマンド早見表を `--merge` に統一（`--squash` の例示を削除）
- `.github/CONTRIBUTING.md` の開発フローとコマンド表を `--merge` に統一
- `--delete-branch` を削除（リポジトリ設定 `deleteBranchOnMerge: true` に変更済みのため不要）

リポジトリ設定は `gh api -X PATCH` で次のように変更済みです（GitHub 側の設定でありリポジトリ内のファイルには現れません）。

| 設定 | 変更後 | 意図 |
| :- | :- | :- |
| `delete_branch_on_merge` | `true` | マージ時にリモートブランチを自動削除。`--delete-branch` の付け忘れを防ぐ |
| `allow_rebase_merge` | `false` | 画面から誤って rebase merge するのを設定側で塞ぐ |
| `allow_merge_commit` | `true`（変更なし） | 統一する方式 |
| `allow_squash_merge` | `true`（変更なし） | 無効化していない。ドキュメント側で「使わない」としている |

```bash
gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,deleteBranchOnMerge
# => {"deleteBranchOnMerge":true,"mergeCommitAllowed":true,"rebaseMergeAllowed":false,"squashMergeAllowed":true}
```

## 確認方法

```bash
# マージ方式としての --rebase / --squash が残っていないこと
grep -rn -- "pr merge\|stack merge\|--squash" --include="*.md" .

# リポジトリ設定
gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,deleteBranchOnMerge
```

## チェックリスト

- [ ] `make check`（lint / format-check / test）が通る
- [x] 整形が必要な変更を含む場合、`make format` を実行済み
- [x] スタックの一部の場合、この層に属する変更だけが入っている

`make check` は `.turbo/cache/` と `packages/graphql/src/generated` の既存の整形エラーで失敗します（Issue #30 の対象）。
本 PR で変更した 3 ファイルはエラーに含まれていません。

## 関連

Closes #33

- Discussion #32（全体: PR のマージ方式の選定） — 本 PR の根拠。Answer 済み
- Discussion #18（全体: Git ブランチ戦略の選定） — 見直し対象の元の決定。#32 へのリンクをコメントで追記済み
- Issue #30（Biome の走査範囲設定と既存コードの整形） — `make check` が失敗している既存要因

> [!NOTE]
> 本 PR は 1 層だけのスタックです。マージは `gh pr merge <番号> --merge` で行ってください。
