### PR TITLE
fix: apps/api / apps/mobile の tsconfig 整備と nest build 回帰の修正 #38

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -10,7 +10,6 @@
     "sourceMap": true,
     "rootDir": "./src",
     "outDir": "./dist",
-    "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,
     "noImplicitAny": false,

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,20 +1,20 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "target": "ES2023",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "ES2023",
     "sourceMap": true,
     "rootDir": "./src",
     "outDir": "./dist",
     "skipLibCheck": true,
-    "strictNullChecks": false,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
-    "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
-  }
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -5,5 +5,16 @@
     "paths": {
       "@/*": ["./src/*"]
     }
-  }
+  },
+  // exclude は継承元とマージされず上書きになるため、expo/tsconfig.base の指定を引き継いだうえで
+  // expo export の出力先 dist を足している（base は noEmit で outDir が無く、自動除外されないため）
+  "exclude": [
+    "node_modules",
+    "babel.config.js",
+    "metro.config.js",
+    "jest.config.js",
+    "android",
+    "ios",
+    "dist"
+  ]
 }


### PR DESCRIPTION
## 概要

#36 で `baseUrl` の削除だけに留まっていた `apps/api` / `apps/mobile` の tsconfig を、他パッケージと同水準に整備する。あわせて #36 で混入した `nest build` の回帰を修正する。

## 変更内容

### `fix(api)`: `nest build` が 2 回目以降に何も出力しない問題

#36 で追加した `rootDir` により、`tsBuildInfoFile` の既定値が `outDir` の外（プロジェクト直下）へ移動していた。`nest-cli.json` の `deleteOutDir: true` は `dist/` しか消さないため incremental の状態だけが残り、2 回目以降の `nest build` が「変更なし」と判定して `dist` を空のまま **exit 0** で終える。

| | 1 回目 | 2 回目 | 3 回目 |
| :- | :-: | :-: | :-: |
| 修正前 | dist 9 エントリ | **0** | **0** |
| 修正後 | dist 9 エントリ | 9 | 9 |

`deleteOutDir` が毎回 `dist` を消す構成では incremental は実質機能しないため、`incremental` をオプションごと削除した。`dev`（`nest start --watch`）は tsc の watch がメモリ上に状態を持つため影響しない。

### `chore`: tsconfig の整備

**`apps/api`**

- NestJS テンプレート由来の緩和（`strictNullChecks` / `noImplicitAny` / `strictBindCallApply` の `false`）を外して `strict: true` に。5 パッケージ中ここだけ緩和されていたが、有効化してもエラーは 0 件
- `forceConsistentCasingInFileNames` / `noFallthroughCasesInSwitch` も `true` へ
- `include` / `exclude` を明示。`outDir` の自動除外に依存しないようにする

**`apps/mobile`**

- `expo/tsconfig.base` が `allowJs: true` かつ `outDir` を持たないため `dist/` が自動除外されず、`expo export` が出力した 1.2 MB の minify 済みバンドルが型チェック対象に入っていた。`exclude` で除外する
- `exclude` は継承元とマージされず**上書き**になるため、`expo/tsconfig.base` の指定（`node_modules` / `babel.config.js` / `metro.config.js` / `jest.config.js` / `android` / `ios`）を引き継いだうえで `dist` を足している。この意図はコメントとして残した

## 確認方法

```bash
# 回帰の確認（修正前は 2 回目以降 dist が空になる）
cd apps/api && rm -rf dist && for i in 1 2 3; do pnpm build; ls dist | wc -l; done

# 型チェック（5 パッケージ + apps/web/tsconfig.node.json）
for d in apps/web apps/api apps/desktop apps/mobile packages/graphql; do (cd $d && ./node_modules/.bin/tsc --noEmit -p tsconfig.json); done
(cd apps/web && ./node_modules/.bin/tsc --noEmit -p tsconfig.node.json)

# ビルド
pnpm -C apps/web build && pnpm -C apps/api build && pnpm -C apps/desktop build && pnpm -C apps/mobile build

make check
```

## チェックリスト

- [x] `make check`（lint / format-check / test）が通る
- [x] 整形が必要な変更を含む場合、`make format` を実行済み
- [x] スタックの一部の場合、この層に属する変更だけが入っている

## 関連

Closes #38

回帰の混入元は #36 / #37。
