### PR TITLE
chore(make): 開発タスクの再編と起動ターゲットの整備 #53

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,11 +35,25 @@ make install    # 依存関係をインストール
 
 mise を使わない場合は、必要なツールを各自で用意したうえで `pnpm install` を実行してください。
 
-### 3. 開発サーバーの起動
+### 3. バックエンドの初期化
+
+初回、または DB を作り直したいときに 1 度だけ実行します。
+コンテナの起動 → Prisma スキーマの反映 → Hasura メタデータの適用 → 動作確認用データの投入までを行います。
 
 ```bash
-make dev
+make backend-init
 ```
+
+### 4. 開発サーバーの起動
+
+バックエンド（PostgreSQL / Hasura / NestJS）と、触りたいフロントエンドを別々のターミナルで起動します。
+
+```bash
+make backend-start    # PostgreSQL + Hasura + NestJS
+make web-start        # Web だけ
+```
+
+すべてまとめて起動する場合は `make dev` を使います。
 
 ## 主要なコマンド
 
@@ -49,13 +63,30 @@ make dev
 | :-------------- | :-------------------------------- |
 | `make`          | タスク一覧の表示                  |
 | `make install`  | 依存関係のインストール            |
-| `make dev`      | 開発サーバーの起動                |
+| `make dev`      | バックエンドと全フロントエンドの起動 |
 | `make build`    | プロジェクトのビルド              |
 | `make lint`     | 静的解析 (Biome) の実行           |
 | `make format`   | コードの自動整形                  |
 | `make format-check` | 整形崩れの確認（書き換えない）  |
 | `make test`     | テストの実行                      |
 | `make check`    | lint / format-check / test をまとめて実行 |
+
+### 起動系コマンド
+
+フロントエンドは Hasura に接続するため、先に `make backend-start`（または `make dev`）が必要です。
+
+| コマンド             | 起動するもの                                   | ポート |
+| :------------------- | :--------------------------------------------- | :----- |
+| `make backend-init`  | DB / Hasura の初期化・マイグレーション（起動はしない） | -      |
+| `make backend-start` | PostgreSQL + Hasura + NestJS                    | 5433 / 8080 / 3001（inspector 9229） |
+| `make backend-stop`  | コンテナの停止                                  | -      |
+| `make frontend-start`| Web + Mobile + Desktop                          | 下記すべて |
+| `make web-start`     | Web (Vite)                                      | 5173   |
+| `make mobile-start`  | Mobile (Expo / Metro)                           | 8081   |
+| `make desktop-start` | Desktop (Electron)                              | 5174（inspector 5858 / DevTools 9222） |
+
+NestJS の待ち受けポートは `PORT` で変更できます（例: `PORT=3100 make backend-start`）。
+変更した場合は `hasura/metadata/actions.yaml` の handler URL も合わせて直してください。
 
 ### Stacked PRs 関連コマンド
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,37 @@
 .DEFAULT_GOAL := help
 
+# タスクの実体は turbo（モノレポのタスクランナー）と docker compose に寄せ、
+# Makefile は「どのターゲットが何を起動するか」の入口だけを持ちます。
+#
+# 単体起動（*-start）は turbo を通さず pnpm から直接叩きます。turbo はタスクの
+# 標準入力を子プロセスへ渡さないため、Expo の対話メニュー（i / a / r など）や
+# Vite のキー操作が効かなくなるためです。turbo の interactive オプションは
+# Terminal UI 必須で、出力をパイプした瞬間にタスクごと失敗するため使いません。
+# 複数アプリを並列で回す dev / frontend-start だけ turbo に任せます。
+TURBO := pnpm exec turbo
+RUN   := pnpm --filter
+
+# VS Code の拡張機能ホスト経由でコマンドを起動すると ELECTRON_RUN_AS_NODE=1 を引き継ぎます。
+# これが立っていると Electron が素の Node として動き、require("electron") が API ではなく
+# バイナリのパス文字列を返すため、main プロセスが app.whenReady() で落ちます。
+# Electron を起動する経路では必ず外します。
+NO_ELECTRON_NODE := env -u ELECTRON_RUN_AS_NODE
+
+# フィルタ名は各 package.json の name です。ディレクトリ名（desktop）と
+# パッケージ名がずれているものがあるため、変数にして 1 か所で管理します。
+API_PKG      := @memo-app/api
+WEB_PKG      := @memo-app/web
+MOBILE_PKG   := @memo-app/mobile
+DESKTOP_PKG  := desktop
+GRAPHQL_PKG  := @repo/graphql
+
 ##@ ヘルプ
 
 .PHONY: help
 help: ## タスク一覧を表示します
 	@awk 'BEGIN { FS = ":.*##" } \
 		/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5); next } \
-		/^[a-zA-Z0-9_-]+:.*##/ { printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+		/^[a-zA-Z0-9_-]+:.*##/ { printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 	@echo ""
 
 ##@ セットアップ
@@ -23,12 +48,66 @@ stack-setup: ## gh-stack 拡張と、エージェント向けスキルを導入�
 ##@ 開発
 
 .PHONY: dev
-dev: ## 開発サーバーを起動します
-	pnpm dev
+dev: backend-up ## バックエンドを起動し、API と全フロントエンドを同時に起動します
+	$(NO_ELECTRON_NODE) $(TURBO) run dev
 
 .PHONY: build
 build: ## プロジェクトをビルドします
-	pnpm build
+	$(TURBO) run build
+
+##@ バックエンド
+
+# backend-up は「コンテナを起動して疎通するまで待つ」だけの内部ターゲットです。
+# `##` を付けていないため make のヘルプには出ません。
+# 待たずに次へ進むと db push や metadata apply が接続エラーで落ちるため、
+# 各ターゲットの前提としてここに集約しています。
+.PHONY: backend-up
+backend-up:
+	docker compose up -d
+	@printf "PostgreSQL の起動を待っています"
+	@until docker compose exec -T postgres pg_isready -U user -d memo >/dev/null 2>&1; do printf "."; sleep 1; done
+	@printf " ready\nHasura の起動を待っています"
+	@until curl -sf http://localhost:8080/healthz >/dev/null 2>&1; do printf "."; sleep 1; done
+	@echo " ready"
+
+.PHONY: backend-init
+backend-init: backend-up ## DB と Hasura を初期化します（スキーマ反映 → メタデータ適用 → シード投入。dummy の既存データは消えます）
+	@command -v hasura >/dev/null 2>&1 || { \
+		echo "hasura CLI が見つかりません。mise install か、公式手順で導入してください。" >&2; \
+		exit 1; \
+	}
+	$(TURBO) run db:push --filter=$(API_PKG)
+	hasura metadata apply --project hasura
+	@$(MAKE) --no-print-directory db-seed
+	@echo "初期化が完了しました。make backend-start で起動できます。"
+
+.PHONY: backend-start
+backend-start: backend-up ## PostgreSQL / Hasura / NestJS をデバッグ起動します（NestJS の inspector は 9229、PORT で待ち受けポートを変更可）
+	$(RUN) $(API_PKG) run dev
+
+.PHONY: backend-stop
+backend-stop: ## PostgreSQL / Hasura のコンテナを停止します
+	docker compose stop
+
+##@ フロントエンド
+
+# フロントエンドは Hasura に接続するため、先に make backend-start が必要です。
+
+.PHONY: frontend-start
+frontend-start: ## Web / Mobile / Desktop をまとめてデバッグ起動します
+	$(NO_ELECTRON_NODE) $(TURBO) run dev --filter=$(WEB_PKG) --filter=$(MOBILE_PKG) --filter=$(DESKTOP_PKG)
+
+.PHONY: web-start
+web-start: ## Web をデバッグ起動します（Vite / http://localhost:5173）
+	$(RUN) $(WEB_PKG) run dev
+
+.PHONY: mobile-start
+mobile-start: ## Mobile をデバッグ起動します（Expo）
+	$(RUN) $(MOBILE_PKG) run dev
+
+.PHONY: desktop-start
+desktop-start: ## Desktop をデバッグ起動します（Electron / renderer 5174・inspector 5858・DevTools 9222）
+	$(NO_ELECTRON_NODE) $(RUN) $(DESKTOP_PKG) run dev
 
 ##@ データベース
 
@@ -37,17 +116,21 @@ build: ## プロジェクトをビルドします
 
 .PHONY: db-push
 db-push: ## Prisma スキーマを DB に反映します
-	pnpm --filter @memo-app/api exec prisma db push
+	$(TURBO) run db:push --filter=$(API_PKG)
 
 .PHONY: db-seed
 db-seed: ## SCR-001 の動作確認用データを投入します（既存の dummy を全削除します）
 	docker compose exec -T postgres psql -U user -d memo -q < apps/api/prisma/seed.sql
 
+.PHONY: codegen
+codegen: ## Hasura のスキーマから GraphQL の型を生成します（Hasura の起動が必要）
+	$(TURBO) run codegen --filter=$(GRAPHQL_PKG)
+
 ##@ 品質
 
 .PHONY: lint
 lint: ## 静的解析を実行します
-	pnpm lint
+	$(TURBO) run lint
 
 .PHONY: format
 format: ## コードを整形します
@@ -59,7 +142,7 @@ format-check: ## 整形崩れがないかを確認します（書き換えませ
 
 .PHONY: test
 test: ## テストを実行します
-	pnpm test
+	$(TURBO) run test
 
 # check は DoD の確認用なので、整形は format ではなく format-check（書き換えなし）を使います。
 # 整形崩れで落ちなければゲートとして意味がなく、並列実行時に --write が lint / test と競合します。

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,9 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "nest start --watch",
+    "dev": "nest start --debug --watch",
     "build": "nest build",
-    "start:debug": "nest start --debug",
     "lint": "biome lint .",
     "postinstall": "prisma generate",
     "db:push": "prisma db push",

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,6 +5,10 @@ import { DomainValidationFilter } from "./infrastructure/filters/domain-validati
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalFilters(new DomainValidationFilter());
-  await app.listen(3000);
+  // 既定は 3001。NestJS の慣例は 3000 ですが、.mcp.json の drawio-mcp-server が
+  // ブラウザ拡張との橋渡しに 3000 を使うため、衝突を避けて 1 つずらしています。
+  // hasura/metadata/actions.yaml の handler がこのポートを指しているため、
+  // 変更する場合は Hasura 側の handler URL も合わせて直すこと。
+  await app.listen(Number(process.env.PORT ?? 3001));
 }
 bootstrap();

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
   renderer: {
     root: resolve("src/renderer"),
     build: { outDir: "dist/renderer" },
+    // apps/web の Vite が既定の 5173 を使うため、ずらして固定します。
+    // make frontend-start で両方を同時に起動しても取り合いになりません。
+    server: { port: 5174 },
     plugins: [react()],
   },
 });

--- a/hasura/README.md
+++ b/hasura/README.md
@@ -28,14 +28,14 @@
 
 ### 通信設定（Handler URL）
 Hasura は Docker コンテナ内で動作するため、ホストマシンで動く NestJS を参照するには以下の URL を使用します。
-- **Action Handler URL**: `http://host.docker.internal:3000/hasura/actions/[Action名]`
+- **Action Handler URL**: `http://host.docker.internal:3001/hasura/actions/[Action名]`
 
 ### 新しい Action を追加する手順
 1. **NestJS で Webhook を実装する**:
    - `apps/api` 内に新しいエンドポイントを作成し、処理を実装します。
 2. **Hasura で Action を定義する**:
    - `hasura console --project hasura` でコンソールを起動。
-   - **Actions** タブで、GraphQL の型定義と `Handler URL` (例: `http://host.docker.internal:3000/hasura/actions/[新規Action名]`) を入力して作成。
+   - **Actions** タブで、GraphQL の型定義と `Handler URL` (例: `http://host.docker.internal:3001/hasura/actions/[新規Action名]`) を入力して作成。
 3. **メタデータを保存する**:
    - ターミナルで `hasura metadata export --project hasura` を実行し、定義をファイルに書き出します。
 4. **型定義を生成する**:

--- a/hasura/config.yaml
+++ b/hasura/config.yaml
@@ -5,4 +5,4 @@ metadata_directory: metadata
 # Prisma がマイグレーションを管理するため、Hasura 側はメタデータのみを対象にします。
 actions:
   kind: synchronous
-  handler_webhook_base_url: http://host.docker.internal:3000
+  handler_webhook_base_url: http://host.docker.internal:3001

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -2,19 +2,19 @@ actions:
   - name: createDummy
     definition:
       kind: synchronous
-      handler: http://host.docker.internal:3000/hasura/actions/createDummy
+      handler: http://host.docker.internal:3001/hasura/actions/createDummy
       timeout: 60
     comment: Create dummy record via NestJS domain logic (Hasura Actions)
   - name: updateDummy
     definition:
       kind: synchronous
-      handler: http://host.docker.internal:3000/hasura/actions/updateDummy
+      handler: http://host.docker.internal:3001/hasura/actions/updateDummy
       timeout: 60
     comment: Update dummy record via NestJS domain logic (Hasura Actions)
   - name: deleteDummy
     definition:
       kind: synchronous
-      handler: http://host.docker.internal:3000/hasura/actions/deleteDummy
+      handler: http://host.docker.internal:3001/hasura/actions/deleteDummy
       timeout: 60
     comment: Delete dummy record via NestJS domain logic (Hasura Actions)
 custom_types:

--- a/turbo.json
+++ b/turbo.json
@@ -3,17 +3,23 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**"]
+      "outputs": ["dist/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]
+    },
+    "test": {
+      "dependsOn": ["^build"]
     },
     "dev": {
       "cache": false,
       "persistent": true
     },
-    "test": {
-      "dependsOn": ["^build"]
+    "codegen": {
+      "cache": false
+    },
+    "db:push": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## 概要

起動と初期化のタスクを Makefile に集約し、バックエンド・各フロントエンドを個別に立ち上げられるようにします。

## 変更内容

- `backend-init` / `backend-start` / `backend-stop` を追加
- `frontend-start` / `web-start` / `mobile-start` / `desktop-start` を追加
- `turbo.json` に `codegen` / `db:push` タスクを追加し、`build` の `outputs` から実体のない `.next/**` を削除
- `apps/api` の `dev` を inspector 付きに変更（重複していた `start:debug` は削除）
- Electron レンダラーの開発ポートを 5174 に固定
- NestJS の既定ポートを 3001 に変更
- `.github/CONTRIBUTING.md` のコマンド一覧を更新

### ポートを 3001 にした理由

`.mcp.json` に定義されている `drawio-mcp-server` がブラウザ拡張との橋渡しに 3000 を使うため、
`make backend-start` が `EADDRINUSE` で落ちます。`.mcp.json` はコミット済みなので全開発者が踏みます。
drawio 側にも `DRAWIO_MCP_EXTENSION_PORT` がありますが、3000 は Draw.io ブラウザ拡張の接続先でもあり、
変更するとリポジトリ外の設定も直す必要があるため、API 側をずらしました。

### 単体起動で turbo を使っていない理由

turbo はタスクの標準入力を子プロセスへ渡さないため、Expo の対話メニューや Vite のキー操作が効かなくなります。
turbo の `interactive` オプションは Terminal UI 必須で、出力をパイプするとタスクごと失敗します。
そのため単体起動は `pnpm --filter` から直接叩き、並列実行に意味がある `dev` / `frontend-start` だけ turbo に任せています。

## 確認方法

```bash
make help            # 全ターゲットが説明付きで出る
make backend-init    # 初期化が一括で通る
make backend-start   # EADDRINUSE が出ず 3001 で待ち受ける
make frontend-start  # 5173 / 5174 / 8081 が衝突せず同時に起動する
```

## チェックリスト

- [x] `make check`（lint / format-check / test）が通る
- [x] 整形が必要な変更を含む場合、`make format` を実行済み
- [x] スタックの一部の場合、この層に属する変更だけが入っている

## 関連

Closes #53
