### PR TITLE
docs: 作業計画の置き場所 project/plan を OKF 形式で追加 #72

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,12 +104,24 @@ Issue 本文のテンプレートは `.github/ISSUE_TEMPLATE/` 配下が正本
 | 置き場所 | 性質 | 役割 | 更新タイミング |
 | :- | :- | :- | :- |
 | GitHub Issue | 作業単位 | やることと完了の記録（AC / DoD / まとめ） | 起票時と完了時 |
+| `project/plan/` | 作業計画（横断） | **複数 Issue にまたがる順序と依存関係**。層の積み順、ブロッカー、判断待ちの項目 | 着手前と、方針が変わったとき |
 | GitHub Discussions | フロー（追記のみ） | 技術選定の議論と証跡（比較した候補・却下の理由）。決定後も残す | 選定の開始〜決定 |
 | GitHub Wiki | ストック（最新のみ） | 採用技術の一覧・概要・**1 行の採用理由**。経緯は Discussion へリンク | 導入 PR のマージ後 |
 | `docs/` | コードと同期 | 設計図（コンテキストマップ / ドメインモデル / ER 図） | 実装 PR と同時 |
 | `README.md` / `.github/` | 手順 | セットアップ・開発フロー・レビュー・運用ルール | 手順が変わったとき |
 
 迷ったら「後から読み返すのは**経緯**か**現状**か」で決めます。経緯なら Discussions、現状なら Wiki です。
+
+### `project/plan/` の使い分け
+
+1 つの Issue に収まる作業に計画書は要りません。**Issue をまたぐ順序と依存が生じたときだけ**作ります。
+
+- 書くのは「どの順で何をやるか」「何が何をブロックしているか」だけ。
+  **完了条件は Issue、選定理由は Discussions、現状は Wiki、設計は `docs/`** にあるものをリンクし、内容をコピーしない。
+- 形式は [OKF（Open Knowledge Format）v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)。
+  YAML frontmatter 付き Markdown のディレクトリで、必須は `type` のみ。`index.md` と `log.md` は予約名。
+- `status` と `stale_after` を必ず入れます。**期限を過ぎた計画は現状とずれている前提**で読みます。
+- 計画が実行され終わったら `status: deprecated` にし、消さずに残します。
 
 ### ツールが場所を決めているファイル
 

--- a/project/plan/auth/findings.md
+++ b/project/plan/auth/findings.md
@@ -1,0 +1,65 @@
+---
+type: Finding
+title: 着手前に知っておくべき事実
+description: 認証・認可の実装に入る前に判明した、Issue 本文には書かれていない 5 つの事実。
+resource: https://github.com/Hitamuki/study-web-modern-stack/issues/20
+tags: [auth, hasura, apps-web, apps-api, 既知の不具合]
+status: stable
+stale_after: 2026-09-18
+generated: { by: claude-code/claude-fable-5, at: 2026-08-17T23:32:00Z }
+---
+
+# 1. `main` は現在 `createDummy` が動かない
+
+Issue [#21](https://github.com/Hitamuki/study-web-modern-stack/issues/21) の副作用。
+`apps/api/src/infrastructure/controllers/hasura-action.controller.ts` の `requireSessionUserId()` が
+`session_variables['x-hasura-user-id']` を必須で読むが、**admin secret 接続では Hasura がこの変数を付けない**。
+そのため Web からのメモ新規作成は必ず 400 になる。
+
+**層 1（JWT モード）で解消する。** それまでは壊れたままである点を承知して進める。
+`updateDummy` / `deleteDummy` はセッション変数を読まないため動く。
+
+# 2. `updateDummy` / `deleteDummy` に所有者チェックが無い
+
+Actions は Hasura のパーミッションを迂回して NestJS → Prisma に直行する。
+`UpdateDummyUseCase` / `DeleteDummyUseCase` は id だけで実行するため、**他人のレコードを更新・削除できる**。
+#21 で追加した `Dummy.isOwnedBy()` は**どこからも呼ばれていない死んだコード**になっている。
+
+→ [layer-actions-guard.md](/project/plan/auth/layer-actions-guard.md) のスコープに含める。
+
+# 3. `dummy.controller.ts` は認証なしのまま残る
+
+`apps/api/src/infrastructure/controllers/dummy.controller.ts`（Hasura を経由しない REST）は
+所有者をリクエストボディから受け取るため、**任意のユーザーになりすませる**。
+元から認証が無いエンドポイントだが、`owner_id` の導入で危険性が上がった。
+
+**この計画のスコープ外。公開前に別 Issue で塞ぐ必要がある**（Issue 未起票）。
+
+# 4. Hasura 側がほぼ空
+
+| ファイル | 現状 |
+| :- | :- |
+| `hasura/metadata/databases/default/tables/public_dummy.yaml` | `table:` の 3 行のみ。**permissions が一切無い** |
+| `hasura/metadata/actions.yaml` | **`permissions:` 未定義**。JWT モードにすると `user` ロールから Action を呼べなくなる |
+| `hasura/metadata/api_limits.yaml` | `{}` |
+| `docker-compose.yml` | 全値が平文ベタ書き。`env_file` 指定なし |
+
+Hasura は **v2.20.0**。
+
+# 5. `apps/web` に足りないもの
+
+- **ルーターが無い**（`App.tsx` は 9 行で `<ApolloProvider><DummyPage /></ApolloProvider>` のみ）
+- `shared/ui/` は `Button.tsx` と `dialog.tsx` の 2 つだけ。`input` / `label` / `card` は無い
+- フォームライブラリもスキーマバリデータも無い。既存パターンは
+  **controlled + props リフトアップ + ページ側で 1 行バリデーション**
+- `@supabase/supabase-js` 未導入
+- **`--pen-danger-bg` / `--pen-gap-lg` が `styles.css` に無い。** ESLint の `better-tailwindcss` が
+  `recommended-error` で効いており、**`@theme` に無いクラスを書くとエラーになる**
+
+## その他
+
+- `packages/graphql/codegen.ts` にも **admin secret がハードコード**されている
+- 生成型 `packages/graphql/src/generated/graphql.ts` に `owner_id` が無い → codegen 再実行が必要
+- Apollo Client は **v4 系**。auth link の書き方が v3 と異なる
+- `ApolloProvider` は 3 箇所から **props 無し**で呼ばれている（mobile は `apps/mobile/App.tsx`。`src/` の外）
+- ルートの `.env.example` は **MCP 専用**。Hasura / Supabase 用の変数の置き場所は未決

--- a/project/plan/auth/index.md
+++ b/project/plan/auth/index.md
@@ -1,0 +1,26 @@
+# 認証・認可の導入
+
+Issue [#20](https://github.com/Hitamuki/study-web-modern-stack/issues/20) の実装計画です。
+
+**目的**: `apps/web` から Hasura の admin secret を消し、ログインしたユーザーが自分のレコードだけを読み書きできる状態にする。
+
+## 読む順序
+
+| # | ファイル | 内容 |
+| :- | :- | :- |
+| 1 | [objective.md](/project/plan/auth/objective.md) | 何を達成すれば完了なのか。層の積み順 |
+| 2 | [findings.md](/project/plan/auth/findings.md) | **着手前に知っておくべき 5 つの事実**（`main` が壊れている件を含む） |
+| 3 | [supabase-setup.md](/project/plan/auth/supabase-setup.md) | ユーザー作業。**これが済むまで実装に入れない** |
+| 4 | [layer-hasura-jwt.md](/project/plan/auth/layer-hasura-jwt.md) | 層 1 |
+| 5 | [layer-apollo-jwt.md](/project/plan/auth/layer-apollo-jwt.md) | 層 2 |
+| 6 | [layer-actions-guard.md](/project/plan/auth/layer-actions-guard.md) | 層 3 |
+| 7 | [layer-web-router.md](/project/plan/auth/layer-web-router.md) | 層 4 |
+| 8 | [layer-web-auth.md](/project/plan/auth/layer-web-auth.md) | 層 5 |
+| 9 | [verification.md](/project/plan/auth/verification.md) | 全層が入った後の検証手順 |
+
+## いま止まっている理由
+
+**ユーザーの作業が 2 つ揃うまで層 1 に入れません。**
+
+1. Supabase プロジェクトの作成 → [supabase-setup.md](/project/plan/auth/supabase-setup.md)
+2. ルーターの選定（Discussion の Answer）→ [layer-web-router.md](/project/plan/auth/layer-web-router.md)

--- a/project/plan/auth/layer-actions-guard.md
+++ b/project/plan/auth/layer-actions-guard.md
@@ -1,0 +1,44 @@
+---
+type: Task
+title: 層 3 — Hasura Actions ハンドラの保護
+description: 裏口を塞ぐ層。共有シークレットの検証と、update/delete の所有者チェック。
+resource: https://github.com/Hitamuki/study-web-modern-stack/issues/26
+tags: [auth, apps-api, 層3, セキュリティ]
+status: stable
+stale_after: 2026-09-18
+generated: { by: claude-code/claude-fable-5, at: 2026-08-17T23:32:00Z }
+---
+
+# 位置づけ
+
+**裏口を塞ぐ層。** Hasura のパーミッションをどれだけ固めても、
+`POST /hasura/actions/createDummy` を直接叩けばドメインロジックを通って素通りしてしまう。
+
+ブランチ: `feat/26-action-guard`（層 2 の上に `gh stack add`）
+
+# やること
+
+完了条件は Issue [#26](https://github.com/Hitamuki/study-web-modern-stack/issues/26) の AC が正本。
+
+## 3-1. 呼び出し元が Hasura であることの検証
+
+- Action 定義（`hasura/metadata/actions.yaml`）に共有シークレットのヘッダを追加し、値は環境変数から
+- ハンドラで検証し、不一致は **401**。NestJS の Guard として実装し、
+  `domain-validation.filter.ts` とは別経路にする
+- `.env.example` に追記
+
+## 3-2. `update` / `delete` の所有者チェック（Issue 本文に無い追加分）
+
+[findings.md](/project/plan/auth/findings.md) の 2 で判明した穴を塞ぐ。
+
+`UpdateDummyUseCase` / `DeleteDummyUseCase` は id だけで実行するため、**他人のレコードを更新・削除できる**。
+Actions は Hasura のパーミッションを迂回するので、Hasura 側の行レベル権限では防げない。
+
+Issue #21 で追加した `Dummy.isOwnedBy()` が**どこからも呼ばれていない死んだコード**になっているので、
+ここで使う。ハンドラがセッション変数から取った所有者と突き合わせ、不一致なら拒否する。
+
+# すでに済んでいること
+
+「所有者を `input` ではなく `session_variables` から取る」部分は
+Issue [#21](https://github.com/Hitamuki/study-web-modern-stack/issues/21) で実装・検証済み。
+`requireSessionUserId()` がそれ。本層で作るのは**その手前の関門**にあたる。

--- a/project/plan/auth/layer-apollo-jwt.md
+++ b/project/plan/auth/layer-apollo-jwt.md
@@ -1,0 +1,43 @@
+---
+type: Task
+title: 層 2 — 共通 Apollo クライアントの JWT 対応
+description: 鍵を運ぶ配管。admin secret を消し、トークンを返す関数を受け取る形にする。
+resource: https://github.com/Hitamuki/study-web-modern-stack/issues/23
+tags: [auth, packages-graphql, 層2]
+status: stable
+stale_after: 2026-09-18
+generated: { by: claude-code/claude-fable-5, at: 2026-08-17T23:32:00Z }
+---
+
+# 位置づけ
+
+**鍵を運ぶ配管。** 3 アプリが共有する層なので、ここを直せば各アプリの仕事は
+「どうトークンを取るか」だけに絞られる。
+
+ブランチ: `feat/23-apollo-jwt`（層 1 の上に `gh stack add`）
+
+# やること
+
+完了条件は Issue [#23](https://github.com/Hitamuki/study-web-modern-stack/issues/23) の AC が正本。
+
+| 対象 | 内容 |
+| :- | :- |
+| `packages/graphql/src/ApolloProvider.tsx` | `adminSecret` を削除し `getToken: () => Promise<string \| null>` を受け取る。**トークンそのものではなく関数**を渡すのは、取得方法が 3 アプリで違うため |
+| 同上 | Apollo Client **v4** の作法で auth link を組む（`SetContextLink` / `ApolloLink.from`）。v3 と書き方が違う |
+| 同上 | `uri` を環境変数から。**3 アプリで読み方が違う**（Vite の `import.meta.env` / Expo の `EXPO_PUBLIC_` / electron-vite）ため、props 経由で各アプリが渡す形が素直 |
+| `packages/graphql/codegen.ts` | ここにも admin secret がハードコードされている。環境変数化する |
+| 生成型 | `pnpm --filter @repo/graphql codegen` を再実行（`owner_id` を含む型に更新） |
+
+# 呼び出し側 3 箇所も直す
+
+`ApolloProvider` は props 無しで 3 箇所から呼ばれている。引数を変えるので全部直す。
+
+| アプリ | ファイル | 対応 |
+| :- | :- | :- |
+| web | `apps/web/src/app/App.tsx` | 層 5 で Supabase のトークンを渡す |
+| desktop | `apps/desktop/src/renderer/main.tsx` | `getToken: async () => null` |
+| mobile | `apps/mobile/App.tsx`（**`src/` の外**） | `getToken: async () => null` |
+
+**mobile / desktop は Issue #25 が保留のため、ビルドは通るが未認証で動かなくなる。**
+これは意図した状態で、Issue [#20](https://github.com/Hitamuki/study-web-modern-stack/issues/20) にも
+「その状態で公開してはいけない」と記録がある。

--- a/project/plan/auth/layer-hasura-jwt.md
+++ b/project/plan/auth/layer-hasura-jwt.md
@@ -1,0 +1,40 @@
+---
+type: Task
+title: 層 1 — Hasura の JWT 認証と行レベル権限
+description: 鍵穴を作る層。JWT モードに切り替え、user ロールの行レベル権限を定義する。
+resource: https://github.com/Hitamuki/study-web-modern-stack/issues/22
+tags: [auth, hasura, 層1]
+status: stable
+stale_after: 2026-09-18
+generated: { by: claude-code/claude-fable-5, at: 2026-08-17T23:32:00Z }
+---
+
+# 位置づけ
+
+**鍵穴を作る層。** これが無いと、上の層が JWT を持っても開ける先が無い。
+
+ブランチ: `feat/22-hasura-jwt`（`main` から）
+前提: [supabase-setup.md](/project/plan/auth/supabase-setup.md) が完了し `project-ref` が確定していること
+
+# やること
+
+完了条件は Issue [#22](https://github.com/Hitamuki/study-web-modern-stack/issues/22) の AC が正本。実装の要点だけ記す。
+
+| 対象 | 内容 |
+| :- | :- |
+| `docker-compose.yml` | `HASURA_GRAPHQL_JWT_SECRET` を環境変数経由で渡す（`jwk_url` は Supabase の JWKS）。**`HASURA_GRAPHQL_UNAUTHORIZED_ROLE` は設定しない**（トークン無しを拒否するため） |
+| `public_dummy.yaml` | `user` ロールの select / insert / update / delete。filter は `owner_id: { _eq: X-Hasura-User-Id }` |
+| 同上（insert） | `set: { owner_id: X-Hasura-User-Id }` で**セッション変数から強制**。クライアントに指定させない |
+| `actions.yaml` | 3 つの Action に `permissions: [{ role: user }]` を追加。**これが無いと `user` ロールから Action を呼べない** |
+| `api_limits.yaml` | 深さ・レート制限（現在 `{}`） |
+| `.env.example` | 追記。置き場所は要判断（ルートは MCP 専用） |
+
+# 効くこと
+
+この層が入ると [findings.md](/project/plan/auth/findings.md) の 1
+（`createDummy` が 400 になる問題）が解消する。Hasura がセッション変数を付けるようになるため。
+
+# 注意
+
+**この層だけ `main` に入っても壊れない。** admin secret を残す限り admin アクセスは生き続けるので、
+Web は今までどおり動く。壊れるのは層 5。

--- a/project/plan/auth/layer-web-auth.md
+++ b/project/plan/auth/layer-web-auth.md
@@ -1,0 +1,70 @@
+---
+type: Task
+title: 層 5 — Web への認証フロー導入と admin secret の削除
+description: 鍵を手に入れる層。SCR-001〜004 を実装し、admin secret を消す。ここが壊れる瞬間。
+resource: https://github.com/Hitamuki/study-web-modern-stack/issues/24
+tags: [auth, apps-web, supabase, 層5]
+status: stable
+stale_after: 2026-09-18
+generated: { by: claude-code/claude-fable-5, at: 2026-08-17T23:32:00Z }
+sources:
+  - resource: https://supabase.com/docs/reference/javascript/auth-resetpasswordforemail
+    title: resetPasswordForEmail と PASSWORD_RECOVERY
+    last_modified: 2026-08-17
+---
+
+# 位置づけ
+
+**鍵を手に入れる層。そして唯一「壊れる瞬間」。**
+admin secret を消した時点で層 2 が入っていないと、Web は何も取得できなくなる。
+
+ブランチ: `feat/24-web-auth`（層 4 の上に `gh stack add`）
+
+# 着手順（この順でないと lint が落ちる）
+
+1. **`apps/web/src/app/styles.css` に `--pen-danger-bg` と `--pen-gap-lg` を追加し、`@theme inline` に割り当てる**
+   ESLint の `better-tailwindcss` が `recommended-error` で効いており、
+   **`@theme` に無いクラスを書くとエラーになる**。これを飛ばすと後の実装が全部落ちる
+2. `@supabase/supabase-js` を catalog（`frontend`）に追加
+3. `npx shadcn add input label card` で不足コンポーネントを追加（`components.json` は
+   `@/shared/ui` に置く設定済み。`shared/ui/` には現在 `Button.tsx` と `dialog.tsx` しかない）
+4. 画面を実装する
+
+# 画面
+
+完了条件は Issue [#24](https://github.com/Hitamuki/study-web-modern-stack/issues/24) の AC が正本。
+意匠の正本は [docs/screen-list.md](../../../docs/screen-list.md) と `docs/screens/*.png`（書き出し済み）。
+
+| 画面 | 内容 |
+| :- | :- |
+| SCR-001 ログイン | エラー帯が出た状態の設計あり |
+| SCR-002 アカウント作成 | 確認メール送信の案内まで |
+| SCR-003 パスワードリセット申請 | `resetPasswordForEmail(email, { redirectTo })` |
+| SCR-004 新しいパスワードの設定 | `onAuthStateChange` の **`PASSWORD_RECOVERY` イベント**で入る |
+
+4 画面とも同じカード構造（アプリ名 → 見出し → 説明 → 入力欄 → 主ボタン → 補助リンク）。
+PC は幅 440px を中央、SP は左右 24px 余白。
+
+エラー表示は `danger-bg` の帯を**見出しと入力欄の間**に置く。
+**入力項目ごとのインラインエラーは持たせない**（設計どおり）。
+
+# 既存パターンに合わせる
+
+フォームライブラリもスキーマバリデータも入っていない。既存は
+**controlled + props リフトアップ + ページ側で 1 行バリデーション**（`DummyForm` / `DummyPage`）。
+**ライブラリは足さない。**
+
+# トークンの保存場所
+
+**supabase-js 既定の localStorage を受容する。**
+
+`apps/web` はサーバーを持たない Vite の SPA で、httpOnly Cookie を発行する主体が無いため。
+Wiki [認証・認可](https://github.com/Hitamuki/study-web-modern-stack/wiki/Authentication-Authorization)
+の推奨（httpOnly Cookie）とは食い違うので、**未達として理由つきで Wiki に明記**し、
+将来の課題（NestJS の BFF 化）として残す。
+
+# 仕上げ
+
+- `ApolloProvider` に `getToken`（`supabase.auth.getSession()` 由来）を渡し、**admin secret を削除**
+- `docs/screen-list.md` の「実装」列を埋める
+- `apps/web/index.html` の `<title>` が `ダミー画面 | メモ` のまま。更新する

--- a/project/plan/auth/layer-web-router.md
+++ b/project/plan/auth/layer-web-router.md
@@ -1,0 +1,42 @@
+---
+type: Task
+title: 層 4 — apps/web へのルーター導入
+description: 認証 4 画面 + ダミー画面の遷移に必要。ライブラリ選定の Discussion が未起票のためブロック中。
+tags: [auth, apps-web, 層4, ブロッカー, 要選定]
+status: draft
+stale_after: 2026-09-18
+generated: { by: claude-code/claude-fable-5, at: 2026-08-17T23:32:00Z }
+---
+
+# 位置づけ
+
+`apps/web` にルーターが無い。`App.tsx` は 9 行で `<ApolloProvider><DummyPage /></ApolloProvider>` を返すだけ。
+SCR-001〜004 の 4 画面 + ダミー画面（SCR-005）の遷移には必要になる。
+
+ブランチ: `feat/NN-web-router`（層 3 の上に `gh stack add`）
+
+> [!WARNING]
+> **Issue も Discussion も未起票。この層だけ準備ができていない。**
+
+# 先に Discussion が要る
+
+ルーターは AGENTS.md の技術選定対象「状態管理・データ取得・UI 基盤」に当たり、
+ルートを定義した後の乗り換えコストが高い。**着手前に Discussion を立てて決着させる。**
+
+候補: React Router / TanStack Router / wouter
+
+選定の進め方は [.github/guides/TECH_DECISIONS.md](../../../.github/guides/TECH_DECISIONS.md) が正本。
+評価軸を先に決めてから候補を並べ、比較表を本文に入れ、結論はコメントで投稿して Answer にマークする。
+
+# やること（決着後）
+
+- 選定したルーターを catalog（`frontend`）に追加
+- 既存のダミー画面を `/` に載せ替える
+- 認証画面のルートを用意する。パスワード再設定の戻り先（`resetPasswordForEmail` の `redirectTo`）が
+  実 URL になるため、層 5 の実装が素直になる
+
+# 代替案（採らなかった）
+
+ルーターを入れず、認証状態と `PASSWORD_RECOVERY` イベントで表示を切り替える案もあった。
+層 5 を認証に集中させられ Discussion 待ちも発生しないが、URL が変わらずブックマークできない。
+**ルーターを先に入れる方針をユーザーが選択した。**

--- a/project/plan/auth/objective.md
+++ b/project/plan/auth/objective.md
@@ -1,0 +1,62 @@
+---
+type: Plan
+title: 認証・認可の導入
+description: apps/web から admin secret を消し、ログインしたユーザーが自分のレコードだけを読み書きできる状態にする。
+resource: https://github.com/Hitamuki/study-web-modern-stack/issues/20
+tags: [auth, supabase, hasura, jwt]
+status: stable
+stale_after: 2026-09-18
+generated: { by: claude-code/claude-fable-5, at: 2026-08-17T23:32:00Z }
+sources:
+  - resource: https://github.com/Hitamuki/study-web-modern-stack/discussions/19
+    title: 認証サービスの選定（Supabase Auth に決着）
+  - resource: https://github.com/Hitamuki/study-web-modern-stack/wiki/Authentication-Authorization
+    title: Wiki 認証・認可
+---
+
+# 目的
+
+フロントエンドが Hasura の admin secret をクライアントに埋め込んで接続している。
+これは手抜きではなく必然で、`dummy` テーブルにパーミッションが 1 つも定義されていないため
+**admin 以外は何も読めない**のが原因である。
+
+したがって順序が決まっている。**下の層が「鍵穴」を作らないと、上の層が「鍵」を持っても意味がない。**
+
+# 完了条件
+
+Issue [#20](https://github.com/Hitamuki/study-web-modern-stack/issues/20) の AC が正本。要点は 3 つ。
+
+1. `apps/web` と `packages/graphql` から `x-hasura-admin-secret` が消えている
+2. 別ユーザーの JWT で他人のレコードが取得できない
+3. 認証なしのリクエストが拒否される
+
+# 層の積み順
+
+AGENTS.md の積み順（`hasura` → `packages/graphql` → `apps/api` → `apps/web`）に従う。
+**Issue は層ごとに分けたまま**、`gh stack` で 1 本に積み、`gh stack merge --merge` で all-or-nothing にマージする。
+
+```text
+main
+ └ feat/22-hasura-jwt       hasura            → #22
+  └ feat/23-apollo-jwt      packages/graphql  → #23
+   └ feat/26-action-guard   apps/api          → #26
+    └ feat/NN-web-router    apps/web          → ルーター導入（Issue 未起票）
+     └ feat/24-web-auth     apps/web          → #24
+```
+
+## なぜ 1 Issue にまとめないか
+
+**`main` が壊れる瞬間を作らないため**であり、Issue の数を減らすこと自体は目的にならない。
+
+- 層 1 単独で `main` に入っても壊れない。admin secret を残す限り admin アクセスは生き続ける
+- **壊れるのは層 5（admin secret の削除）**。層 2 が無いと Web は何も取得できなくなる
+- したがって層 2 と層 5 は必ず同時に `main` へ入る必要があり、それを保証するのがスタックの all-or-nothing マージ
+
+1 PR に統合すると 4 領域が 1 つの差分になり、「レビュアーが 15 分で読み切れる」サイズを超える。
+
+# 対象外
+
+- `apps/mobile` / `apps/desktop` への認証導入（Issue #25。開発停止中）。
+  層 2 で共通クライアントを変えるため、**両アプリはビルドは通るが未認証**の状態になる
+- TLS の有効化（Issue #27）
+- `dummy.controller.ts`（Hasura を経由しない REST）の保護 → [findings.md](/project/plan/auth/findings.md) を参照

--- a/project/plan/auth/supabase-setup.md
+++ b/project/plan/auth/supabase-setup.md
@@ -1,0 +1,73 @@
+---
+type: Task
+title: Supabase プロジェクトのセットアップ
+description: 層 1 のブロッカー。プロジェクト作成と Custom Access Token Hook の登録はユーザー本人の作業。
+resource: https://github.com/Hitamuki/study-web-modern-stack/discussions/19
+tags: [auth, supabase, ブロッカー, ユーザー作業]
+status: stable
+stale_after: 2026-09-18
+generated: { by: claude-code/claude-fable-5, at: 2026-08-17T23:32:00Z }
+sources:
+  - resource: https://supabase.com/docs/guides/auth/auth-hooks/custom-access-token-hook
+    title: Custom Access Token Hook
+    last_modified: 2026-08-17
+  - resource: https://supabase.com/docs/guides/auth/signing-keys
+    title: JWT Signing Keys
+    last_modified: 2026-08-17
+---
+
+# これが済むまで実装に入れない
+
+Issue [#22](https://github.com/Hitamuki/study-web-modern-stack/issues/22) の AC が
+「発行した JWT で自分のレコードだけ取得できる」「別ユーザーの JWT では取得できない」を要求している。
+**実際に Supabase が署名した JWT が無いと検証できない。**
+
+サインアップとダッシュボード操作は代行できないため、**ユーザー本人の作業**。
+
+# 手順
+
+1. supabase.com でサインアップ（GitHub アカウント可・クレジットカード不要）
+2. プロジェクトを作成（無料プロジェクトは 2 つまで）
+3. SQL Editor で下記の Hook 関数を作成する
+4. Authentication → Hooks で Custom Access Token として登録する
+5. **`project-ref` を共有する** → `jwk_url` が確定して層 1 に着手できる
+
+```sql
+create or replace function public.custom_access_token_hook(event jsonb)
+returns jsonb language plpgsql stable as $$
+begin
+  return jsonb_set(event, '{claims,https://hasura.io/jwt/claims}', jsonb_build_object(
+    'x-hasura-default-role',  'user',
+    'x-hasura-allowed-roles', jsonb_build_array('user'),
+    'x-hasura-user-id',       event->>'user_id'
+  ));
+end; $$;
+
+grant execute on function public.custom_access_token_hook to supabase_auth_admin;
+revoke execute on function public.custom_access_token_hook from authenticated, anon, public;
+```
+
+> [!IMPORTANT]
+> **Hook はアプリのテーブルを読まない純粋関数にする。**
+> Hook は Supabase 側の PostgreSQL で動く。ローカル開発ではアプリの DB が
+> Docker の別インスタンスなので、アプリのテーブルは見えない。
+> 当面はロールを固定（全員 `user`）してこの制約を満たす。
+
+# 確定する値
+
+| 値 | 用途 |
+| :- | :- |
+| `project-ref` | `jwk_url` = `https://<project-ref>.supabase.co/auth/v1/.well-known/jwks.json` |
+| anon key（publishable key） | `apps/web` の Supabase クライアント初期化 |
+
+# 検証
+
+Hook の登録後、ログインして得た JWT をデコードし、
+`https://hasura.io/jwt/claims` の下に `x-hasura-user-id` が入っていることを確認する。
+**ここが入っていないと層 1 以降がすべて空振りする。**
+
+# 未検証の懸念
+
+**Supabase Free は 7 日間の低活動でプロジェクトが一時停止し、90 日で永久削除される。**
+学習用に常設したい方針と衝突するため、Discussion
+[#29](https://github.com/Hitamuki/study-web-modern-stack/discussions/29)（ホスティング先の選定）で扱う。

--- a/project/plan/auth/verification.md
+++ b/project/plan/auth/verification.md
@@ -1,0 +1,89 @@
+---
+type: Runbook
+title: 全層マージ後の検証手順
+description: 5 層が入った後に、認証と認可が実際に効いていることを確認する手順。
+resource: https://github.com/Hitamuki/study-web-modern-stack/issues/20
+tags: [auth, 検証, runbook]
+status: stable
+stale_after: 2026-09-18
+generated: { by: claude-code/claude-fable-5, at: 2026-08-17T23:32:00Z }
+---
+
+# 前提
+
+`gh stack merge --merge` → `gh stack sync --prune` が済んでいること。
+Supabase に**検証用ユーザーを 2 人**作り、それぞれの JWT を用意する。
+
+シードは `apps/api/prisma/seed.sql` が 2 ユーザー分に分けてある
+（A: `...0001` が 3 件 / B: `...0002` が 1 件）。**この UUID を実ユーザーの ID に差し替えて使う。**
+
+```bash
+make backend-init   # スキーマ反映 → メタデータ適用 → シード投入
+```
+
+# 1. 自分のレコードだけ見える
+
+```bash
+curl -s http://localhost:8080/v1/graphql \
+  -H "Authorization: Bearer $TOKEN_A" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ dummy { id content } }"}'
+```
+
+ユーザー A のレコードのみが返ること。
+
+# 2. 他人のレコードが見えない
+
+`$TOKEN_B` で同じクエリを投げ、**A のレコードが 1 件も含まれない**こと。
+
+# 3. 認証なしが拒否される
+
+```bash
+curl -s http://localhost:8080/v1/graphql \
+  -H 'Content-Type: application/json' -d '{"query":"{ dummy { id } }"}'
+```
+
+エラーになること（`HASURA_GRAPHQL_UNAUTHORIZED_ROLE` を設定していないため）。
+
+# 4. Actions が Hasura 以外から叩けない
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost:3001/hasura/actions/createDummy \
+  -H 'Content-Type: application/json' -d '{"input":{"content":"x"}}'
+```
+
+**401** であること。
+
+# 5. 他人のレコードを更新・削除できない
+
+B のトークンで A のレコード id を指定して `updateDummy` / `deleteDummy` を実行し、拒否されること。
+[layer-actions-guard.md](/project/plan/auth/layer-actions-guard.md) の 3-2 で入れる所有者チェックの確認。
+
+# 6. admin secret が消えている
+
+```bash
+grep -rn "x-hasura-admin-secret\|myadminsecretkey" apps/web packages/graphql
+```
+
+`apps/web` と `packages/graphql` にヒットが無いこと。
+`docker-compose.yml` と `hasura/config.yaml` には残る（サーバー側の運用値）。
+
+# 7. 画面から通しで確認
+
+```bash
+make backend-start   # 別ターミナル
+make web-start
+```
+
+アカウント作成 → 確認メール → ログイン → 自分のメモだけ表示 → ログアウト → 再度ログインを求められる。
+パスワードリセットは申請 → メールのリンク → 新しいパスワード設定 → 新パスワードでログイン。
+
+# 8. 静的チェック
+
+```bash
+make check
+```
+
+> [!NOTE]
+> `make test` は「実行対象のタスクが無い」状態で終了する。
+> **リポジトリにテストが 1 本も無い**既存の状態で、この計画の対象外。

--- a/project/plan/index.md
+++ b/project/plan/index.md
@@ -1,0 +1,34 @@
+# 作業計画
+
+複数の Issue にまたがる実装計画の置き場です。
+形式は [OKF（Open Knowledge Format）v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) に従います。
+
+## ここに書くもの・書かないもの
+
+計画は「順序と依存関係」だけを持ちます。**内容は他の置き場所からコピーせず、リンクで参照します。**
+
+| 知りたいこと | 見る場所 |
+| :- | :- |
+| **どの順で何をやるか。何が何をブロックしているか** | **ここ（`project/plan/`）** |
+| その作業の完了条件は何か | GitHub Issue |
+| なぜその技術を選んだか | GitHub Discussions |
+| 今このプロジェクトは何を使っているか | GitHub Wiki |
+| どういう設計になっているか | `docs/` |
+| どうやって動かすか | `README.md` / `.github/` |
+
+書き分けの正本は [AGENTS.md](../../AGENTS.md) の「ドキュメントの置き場所」です。
+
+## 読み方
+
+各ファイルの YAML frontmatter に `status` と `stale_after` があります。
+`stale_after` を過ぎた計画は**現状とずれている可能性がある**ものとして扱ってください。
+
+`verified` が無いものは**まだ誰も確認していない**（unverified）という意味です。
+
+## 一覧
+
+| ディレクトリ | 内容 | 状態 |
+| :- | :- | :- |
+| [auth/](/project/plan/auth/index.md) | 認証・認可の導入（Issue #20）。Supabase Auth 採用後の 5 層の積み方 | 進行中 |
+
+更新履歴は [log.md](/project/plan/log.md) を参照してください。

--- a/project/plan/log.md
+++ b/project/plan/log.md
@@ -1,0 +1,11 @@
+# 更新履歴
+
+新しいものが上です。計画の追加・方針の変更・陳腐化をここに記録します。
+
+## 2026-08-18
+
+- `project/plan/` を新設（Issue [#72](https://github.com/Hitamuki/study-web-modern-stack/issues/72)）。
+  形式は OKF v0.2。AGENTS.md の「ドキュメントの置き場所」に 1 行追加した。
+- [auth/](/project/plan/auth/index.md) を追加。認証・認可（Issue
+  [#20](https://github.com/Hitamuki/study-web-modern-stack/issues/20)）の 5 層の積み方と、
+  着手前に判明した 5 つの事実を記録。


### PR DESCRIPTION
## 概要

複数の Issue にまたがる作業計画の置き場所として `project/plan/` を新設し、
最初の中身に認証・認可（#20）の計画を置いた。形式は **OKF（Open Knowledge Format）v0.2**。

## 変更内容

### `project/plan/` の新設（OKF v0.2）

[Google Cloud が 2026-06 に公開した仕様](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)で、
YAML frontmatter 付き Markdown のディレクトリ。必須フィールドは `type` のみ、`index.md` / `log.md` が予約名。

**なぜこの形式か**: 計画書は人間もエージェントも読む。スキーマレジストリもツールも要らず `git clone` できれば読める。
`status` / `stale_after` / `generated` / `verified` が frontmatter に入るため、
**「この計画はいつ古くなるか」「誰が確認したか」が機械可読**になる。

```text
project/plan/
├── index.md          （予約名・バンドルルートの一覧）
├── log.md            （予約名・更新履歴）
└── auth/
    ├── index.md      （予約名・読む順序）
    ├── objective.md          type: Plan
    ├── findings.md           type: Finding
    ├── supabase-setup.md     type: Task
    ├── layer-hasura-jwt.md   type: Task
    ├── layer-apollo-jwt.md   type: Task
    ├── layer-actions-guard.md type: Task
    ├── layer-web-router.md   type: Task
    ├── layer-web-auth.md     type: Task
    └── verification.md       type: Runbook
```

`verified` はどのファイルにも書いていない。OKF の定義では **`verified` が無い = unverified**（未確認）で、
実際まだ誰もレビューしていないため。人が確認したら `verified: { by: human:Hitamuki, at: ... }` を足す。

### AGENTS.md の更新

「ドキュメントの置き場所」表に 1 行追加し、他の置き場所との書き分けを節として明記した。
**表に載せずにディレクトリだけ増やすと、これまで直してきた「ルールと実態の乖離」を自分で作ることになる**ため。

### 計画の中身で新たに書いたこと

Issue 本文には無い、着手前の調査で判明した事実を `findings.md` にまとめた。とくに次の 2 つは
どの Issue にも書かれていない。

- **`main` は現在 `createDummy` が動かない**（#21 の副作用）。`requireSessionUserId()` が
  `session_variables` を必須で読むが、admin secret 接続では Hasura がこの変数を付けないため必ず 400 になる。層 1 で解消する
- **`updateDummy` / `deleteDummy` に所有者チェックが無い**。Actions は Hasura のパーミッションを迂回するため、
  他人のレコードを更新・削除できる。#21 で追加した `Dummy.isOwnedBy()` は現在どこからも呼ばれていない死んだコード

## 確認方法

### OKF v0.2 への適合

```bash
# 非予約 .md すべてに解析可能な frontmatter と空でない type があること
python3 - <<'PY'
import glob, yaml
for f in sorted(glob.glob("project/plan/**/*.md", recursive=True)):
    if f.endswith(("index.md", "log.md")): continue
    d = yaml.safe_load(open(f).read().split("---", 2)[1])
    assert d.get("type"), f
    print("ok", f, d["type"])
PY
```

手元で 9 ファイルすべて通ることを確認済み。相対リンク 23 本もすべて解決することを確認した。

### 内容の重複が無いこと

`project/plan/` には完了条件・選定理由・現状・設計図をコピーしていない。
すべて Issue / Discussions / Wiki / `docs/` へのリンクになっている。

```bash
make check
```

## レビューで見てほしい点

- **`project/` というトップレベルディレクトリを増やしたこと。** `docs/` の下に置く案もあったが、
  `docs/` は AGENTS.md で「コードと同期する設計図」と役割が定義済みで、性質が違うため分けた。
- **OKF を採用したこと。** 単なる Markdown でも用は足りる。`status` / `stale_after` で
  陳腐化を検出できる点に価値を見たが、過剰なら素の Markdown に落とせる。
- 技術選定の Discussion は立てていない。AGENTS.md の対象（フレームワーク・データ基盤・UI 基盤など
  乗り換えコストが高いもの）に当たらず、**ドキュメントの書式**であり後から変更が容易なため。
  必要なら立て直す。

## チェックリスト

- [x] `make check`（lint / format-check / test）が通る
- [x] 整形が必要な変更を含む場合、`make format` を実行済み
- [x] スタックの一部の場合、この層に属する変更だけが入っている

> [!NOTE]
> `make test` は「実行対象のタスクが無い」状態で終了する（リポジトリにテストが 1 本も無い既存の状態）。

## 関連

Closes #72

Issue #20（この計画の対象）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
